### PR TITLE
Prijava ispita - inicijalno datum ispita kod kreiranja termina

### DIFF
--- a/nastavnik/prijava_ispita.php
+++ b/nastavnik/prijava_ispita.php
@@ -428,11 +428,24 @@ while ($r10=db_fetch_row($q10)) {
 // Forma za unos novog ispitnog termina ili editovanje postojećeg
 
 if ($dan==0) {
-	$dan=$dan1=date('d'); $mjesec=$mjesec1=date('m'); $godina=$godina1=date('Y');
-	$sat=$sat1=date('H'); $minuta=$minuta1=date('i'); $sekunda=$sekunda1=date('s');
-	$limit=0;
-	// Ako akcija nije izmjena, brišemo vrijednost varijable termin
-	$termin=0;
+$dan=$dan1=date('d'); $mjesec=$mjesec1=date('m'); $godina=$godina1=date('Y');
+$sat=$sat1=date('H'); $minuta=$minuta1=date('i'); $sekunda=$sekunda1=date('s');
+$limit=0;
+// Ako akcija nije izmjena, brišemo vrijednost varijable termin
+$termin=0;
+}
+
+// Ako unosimo novi termni za ispit - daj datum za koji je ispit postavljen
+if($_REQUEST["akcija"] != "izmijeni" and $_REQUEST["akcija"] != "studenti"){
+	$datum = db_fetch1(db_query("SELECT * FROM ispit where id = ".$ispit))[3] ? : 0;
+	$dan = explode("-", $datum)[2];
+	$mjesec = explode("-", $datum)[1];
+	$godina = explode("-", $datum)[0];
+
+	$dan1 = $dan; $mjesec1 = $mjesec; $godina1 = $godina;
+	
+	$sat = "09";  $minuta = "00";  $sekunda = "00";
+	$sat1 = "09"; $minuta1 = "00"; $sekunda1 = "00";
 }
 
 
@@ -454,7 +467,7 @@ if ($dan==0) {
 
 	&nbsp;&nbsp; <input type="text" name="sat" size="2" value="<?=$sat?>"> <b>:</b> <input type="text" name="minuta" size="2" value="<?=$minuta?>"> <b>:</b> <input type="text" name="sekunda" size="2" value="<?=$sekunda?>">
 	<br/><br/>
-
+	
 	Krajnji rok za prijavu ispita:
 	<br/>
 	<?=datectrl($dan1, $mjesec1, $godina1, "1"); ?>
@@ -471,12 +484,6 @@ if ($dan==0) {
 </form>
 
 <?
-
-
-
-
-
-
 }
 
 ?>


### PR DESCRIPTION
Inicijalno postavi datum termina kao i datum prijave ispita na dan ispita koji je već definisan kreiranjem "Ispita" u tabeli "ispit". Možda treba razmisliti o činjenici da se "Rok za prijavu postavi na 23:59:00" dan prije nego dan ispita? 

P.S. Vrijeme sam umjesto current-time postavio na 09:00:00 (Šansa da će se ispit održavati u hh:49:28 skoro pa nikakva).